### PR TITLE
人狼チェスシステム

### DIFF
--- a/app/src/adapters/api/game/api.ts
+++ b/app/src/adapters/api/game/api.ts
@@ -50,7 +50,7 @@ export const useGameDataAPI = (): GameAPI => ({
         board: boardFormatted,
         turn: latestGame.turn,
         fiftyMoveRuleTurn: latestGame.fiftyMoveRuleTurn,
-        playing: "",
+        currentPlayer: "",
       },
       playerColor: latestGame.playerColor,
     };

--- a/app/src/adapters/api/game/api.ts
+++ b/app/src/adapters/api/game/api.ts
@@ -50,6 +50,7 @@ export const useGameDataAPI = (): GameAPI => ({
         board: boardFormatted,
         turn: latestGame.turn,
         fiftyMoveRuleTurn: latestGame.fiftyMoveRuleTurn,
+        playing: "",
       },
       playerColor: latestGame.playerColor,
     };

--- a/app/src/components/features/game/GameContainer.tsx
+++ b/app/src/components/features/game/GameContainer.tsx
@@ -16,7 +16,7 @@ export function GameContainer() {
 
   useEffect(() => {
     // クエリパラメータからプレイヤーの色を取得
-    const playerColorParam = searchParams.get("player");
+    const playerColorParam = searchParams.get("color");
     if (playerColorParam === "white" || playerColorParam === "black") {
       setPlayerColor(playerColorParam);
     } else {

--- a/app/src/components/ui/Modal.tsx
+++ b/app/src/components/ui/Modal.tsx
@@ -77,7 +77,7 @@ export function Modal({
         <div className="flex items-center justify-between">
           <Heading2 className="hidden md:block">{header}</Heading2>
           <Heading4 className="md:hidden">{header}</Heading4>
-          {!isNullOrUndefined(handleCloseModal) && (
+          {isNullOrUndefined(handleCloseModal) || (
             <button
               className="hover:bg-black hover:bg-opacity-10 p-0.5 rounded"
               aria-label="モーダルを閉じる"

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -28,6 +28,8 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
     isRuleBookOpen,
     isRetireModalOpen,
     suspectingPlayer,
+    isResultModalOpen,
+    handleOpenResultModal,
     handleClickSuspectingPlayer,
     handleClickMass,
     handleClickPromotion,
@@ -43,7 +45,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
     playerColor,
   });
 
-  const isResultModalOpen =
+  const isFinished =
     (gameStatus.player !== "playing" && gameStatus.player !== "checked") ||
     (gameStatus.enemy !== "playing" && gameStatus.enemy !== "checked");
 
@@ -160,9 +162,20 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
       {isRuleBookOpen && <RuleBook handleCloseRuleBook={handleCloseRuleBook} />}
       {isSuspectModalOpen && (
         <SuspectModal
+          mode="suspect"
           suspectingPlayer={suspectingPlayer}
           handleSuspect={handleClickSuspectingPlayer}
           handleCloseSuspectModal={handleCloseSuspectModal}
+          players={players}
+        />
+      )}
+      {isFinished && (
+        <SuspectModal
+          mode="poll"
+          suspectingPlayer={suspectingPlayer}
+          handleSuspect={handleClickSuspectingPlayer}
+          handleCloseSuspectModal={handleCloseSuspectModal}
+          handleOpenResultModal={handleOpenResultModal}
           players={players}
         />
       )}

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -117,7 +117,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
                 className={`mr-4 md:text-xl ${isPlayerTurn ? "text-blue-400" : "text-red-400"}`}
               >
                 <div>
-                  {boardStatus.playing}
+                  {boardStatus.currentPlayer}
                   のターンです
                 </div>
               </div>

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -42,6 +42,9 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
 
   return (
     <div className="flex flex-col">
+      <div>
+        {isPlayerTurn ? 'マイターン' : '相手ターン'}
+      </div>
       <div className="flex">
         <div className="flex flex-col-reverse">
           {["1", "2", "3", "4", "5", "6", "7", "8"].map((col) => (
@@ -84,6 +87,10 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
             {col}
           </div>
         ))}
+      </div>
+      <div className="flex">
+        <div>怪しい</div>
+        <div>投票</div>
       </div>
       {/* playerが黒のときリロード時に「相手のターンです」がちらつくため */}
       {isLoading ? (

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -86,7 +86,13 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
         ))}
       </div>
       <div className="flex justify-end mb-4">
-        <div className="w-14 h-14 rounded-full bg-primary hover:bg-primary-dark flex justify-center items-center text-sm text-white">怪しい</div>
+        <Button
+          onClick={() => {}}
+          variant="primary"
+          className="w-20 h-20 rounded-full text-sm text-white"
+        >
+          怪しい
+        </Button>
       </div>
       {/* playerが黒のときリロード時に「相手のターンです」がちらつくため */}
       {isLoading ? (
@@ -95,23 +101,16 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
         <Card>
           <div className="flex flex-col gap-y-4">
             <div className="flex justify-between items-start">
-              <div className="flex flex-col">
+              <div>
                 <span>{boardStatus.turn + 1}手目</span>
-                <span>ターン：{boardStatus.playing}</span>
               </div>
               <div
                 className={`mr-4 md:text-xl ${isPlayerTurn ? "text-blue-400" : "text-red-400"}`}
               >
-                {isPlayerTurn ? (
-                  <div>
-                    あなた ({playerColor === "white" ? "白" : "黒"})
-                    のターンです
-                  </div>
-                ) : (
-                  <div>
-                    相手 ({playerColor === "white" ? "黒" : "白"}) のターンです
-                  </div>
-                )}
+                <div>
+                  {boardStatus.playing}
+                  のターンです
+                </div>
               </div>
             </div>
             <div className="flex justify-end gap-x-8">

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -96,7 +96,10 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
         <Card>
           <div className="flex flex-col gap-y-4">
             <div className="flex justify-between items-start">
-              <div>{boardStatus.turn + 1}手目</div>
+              <div className="flex flex-col">
+                <span>{boardStatus.turn + 1}手目</span>
+                <span>ターン：{boardStatus.playing}</span>
+              </div>
               <div
                 className={`mr-4 md:text-xl ${isPlayerTurn ? "text-blue-400" : "text-red-400"}`}
               >

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -42,9 +42,6 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
 
   return (
     <div className="flex flex-col">
-      <div>
-        {isPlayerTurn ? 'マイターン' : '相手ターン'}
-      </div>
       <div className="flex">
         <div className="flex flex-col-reverse">
           {["1", "2", "3", "4", "5", "6", "7", "8"].map((col) => (

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -5,6 +5,7 @@ import { PromotionModal } from "@/components/ui/chess/modal/Promotion";
 import { ResultModal } from "@/components/ui/chess/modal/Result";
 import { RetireModal } from "@/components/ui/chess/modal/Retire";
 import { RuleBook } from "@/components/ui/chess/modal/RuleBook";
+import { SuspectModal } from "@/components/ui/chess/modal/Suspect";
 import { useChessBoard } from "@/components/ui/chess/useChessBoard";
 import { isNullOrUndefined } from "@/utils/typeGuard";
 
@@ -21,6 +22,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
     gameStatus,
     isLoading,
     isPlayerTurn,
+    isSuspectModalOpen,
     promotionInfo,
     isRuleBookOpen,
     isRetireModalOpen,
@@ -32,6 +34,8 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
     handleCloseRetireModal,
     handleRetire,
     handleReturnHome,
+    handleClickSuspectModal,
+    handleCloseSuspectModal,
   } = useChessBoard({
     playerColor,
   });
@@ -87,7 +91,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
       </div>
       <div className="flex justify-end mb-4">
         <Button
-          onClick={() => {}}
+          onClick={handleClickSuspectModal}
           variant="primary"
           className="w-20 h-20 rounded-full text-sm text-white"
         >
@@ -151,6 +155,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
         />
       )}
       {isRuleBookOpen && <RuleBook handleCloseRuleBook={handleCloseRuleBook} />}
+      {isSuspectModalOpen && <SuspectModal handleCloseSuspectModal={handleCloseSuspectModal} />}
     </div>
   );
 }

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -16,6 +16,7 @@ type ChessBoardProps = {
 
 export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
   const {
+    players,
     boardStatus,
     selectedPiecePosition,
     movablePositions,
@@ -155,7 +156,12 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
         />
       )}
       {isRuleBookOpen && <RuleBook handleCloseRuleBook={handleCloseRuleBook} />}
-      {isSuspectModalOpen && <SuspectModal handleCloseSuspectModal={handleCloseSuspectModal} />}
+      {isSuspectModalOpen && (
+        <SuspectModal
+          handleCloseSuspectModal={handleCloseSuspectModal}
+          players={players}
+        />
+      )}
     </div>
   );
 }

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -85,9 +85,8 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
           </div>
         ))}
       </div>
-      <div className="flex">
-        <div>怪しい</div>
-        <div>投票</div>
+      <div className="flex justify-end mb-4">
+        <div className="w-14 h-14 rounded-full bg-primary hover:bg-primary-dark flex justify-center items-center text-sm text-white">怪しい</div>
       </div>
       {/* playerが黒のときリロード時に「相手のターンです」がちらつくため */}
       {isLoading ? (

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -27,6 +27,8 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
     promotionInfo,
     isRuleBookOpen,
     isRetireModalOpen,
+    suspectingPlayer,
+    handleClickSuspectingPlayer,
     handleClickMass,
     handleClickPromotion,
     handleCloseRuleBook,
@@ -94,7 +96,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
         <Button
           onClick={handleClickSuspectModal}
           variant="primary"
-          className="w-20 h-20 rounded-full text-sm text-white"
+          className="w-20 h-20 rounded-full text-sm text-white font-bold"
         >
           怪しい
         </Button>
@@ -158,6 +160,8 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
       {isRuleBookOpen && <RuleBook handleCloseRuleBook={handleCloseRuleBook} />}
       {isSuspectModalOpen && (
         <SuspectModal
+          suspectingPlayer={suspectingPlayer}
+          handleSuspect={handleClickSuspectingPlayer}
           handleCloseSuspectModal={handleCloseSuspectModal}
           players={players}
         />

--- a/app/src/components/ui/chess/ChessBoard.tsx
+++ b/app/src/components/ui/chess/ChessBoard.tsx
@@ -167,6 +167,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
           handleSuspect={handleClickSuspectingPlayer}
           handleCloseSuspectModal={handleCloseSuspectModal}
           players={players}
+          currentPlayer={boardStatus.currentPlayer}
         />
       )}
       {isFinished && (
@@ -177,6 +178,7 @@ export function ChessBoard({ playerColor, className = "" }: ChessBoardProps) {
           handleCloseSuspectModal={handleCloseSuspectModal}
           handleOpenResultModal={handleOpenResultModal}
           players={players}
+          currentPlayer={boardStatus.currentPlayer}
         />
       )}
     </div>

--- a/app/src/components/ui/chess/initialBoard.ts
+++ b/app/src/components/ui/chess/initialBoard.ts
@@ -95,5 +95,6 @@ export const setUpInitialBoard = (
     ],
     turn: 0,
     fiftyMoveRuleTurn: 0,
+    playing: "",
   };
 };

--- a/app/src/components/ui/chess/initialBoard.ts
+++ b/app/src/components/ui/chess/initialBoard.ts
@@ -95,6 +95,6 @@ export const setUpInitialBoard = (
     ],
     turn: 0,
     fiftyMoveRuleTurn: 0,
-    playing: "",
+    currentPlayer: "",
   };
 };

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -1,6 +1,7 @@
+import { useState, useEffect } from "react";
+
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/button/Button";
-import { useState, useEffect } from "react";
 
 type SuspectModalProps = {
   mode: "suspect" | "poll";
@@ -22,18 +23,21 @@ export function SuspectModal({
   const [timeLeft, setTimeLeft] = useState(30);
 
   useEffect(() => {
-    if (!handleOpenResultModal) return;
-    if (mode === "poll" && timeLeft > 0) {
+    if (handleOpenResultModal === undefined || mode !== "poll") return;
+    if (timeLeft > 0) {
       const timer = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
-      return () => clearTimeout(timer);
-    } else if (mode === "poll" && timeLeft === 0) {
+      clearTimeout(timer);
+    } else {
       handleCloseSuspectModal();
       handleOpenResultModal();
     }
   }, [timeLeft]);
 
   return (
-    <Modal header="怪しいプレイヤー選択" handleCloseModal={handleCloseSuspectModal}>
+    <Modal
+      header="怪しいプレイヤー選択"
+      handleCloseModal={handleCloseSuspectModal}
+    >
       {mode === "poll" && (
         <div>
           <p className="mb-4 text-center font-bold text-xl">

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -10,6 +10,7 @@ type SuspectModalProps = {
   handleSuspect: (name: string) => void;
   handleCloseSuspectModal: () => void;
   handleOpenResultModal?: () => void;
+  currentPlayer: string;
 };
 
 export function SuspectModal({
@@ -19,6 +20,7 @@ export function SuspectModal({
   handleCloseSuspectModal,
   handleSuspect,
   handleOpenResultModal,
+  currentPlayer,
 }: SuspectModalProps) {
   const [timeLeft, setTimeLeft] = useState(30);
 
@@ -47,17 +49,19 @@ export function SuspectModal({
       )}
       <div className="w-full flex justify-center">
         <div className="flex gap-2 mb-4 flex-wrap">
-          {players.map((player) => (
-            <Button
-              onClick={() => handleSuspect(player)}
-              variant="secondary"
-              key={player}
-              disabled={player === suspectingPlayer}
-              className="h-8 md:h-16 px-3 md:px-6 border border-primary border-solid rounded flex justify-center items-center"
-            >
-              {player}
-            </Button>
-          ))}
+          {players
+            .filter((player) => player !== currentPlayer)
+            .map((player) => (
+              <Button
+                onClick={() => handleSuspect(player)}
+                variant="secondary"
+                key={player}
+                disabled={player === suspectingPlayer}
+                className="h-8 md:h-16 px-3 md:px-6 border border-primary border-solid rounded flex justify-center items-center"
+              >
+                {player}
+              </Button>
+            ))}
         </div>
       </div>
       <div className="flex flex-col md:flex-row justify-end items-center gap-4">

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -24,6 +24,8 @@ export function SuspectModal({
           <button
             onClick={() => handleSuspect(player)}
             key={player}
+            type="button"
+            disabled={player === suspectingPlayer}
             className="h-16 px-6 border border-primary border-solid rounded flex justify-center items-center"
           >
             {player}

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -1,0 +1,29 @@
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/button/Button";
+
+type SuspectModalProps = {
+  handleSuspect?: () => Promise<void>;
+  handleCloseSuspectModal: () => void;
+};
+
+export function SuspectModal({
+  handleCloseSuspectModal,
+  handleSuspect,
+}: SuspectModalProps) {
+  return (
+    <Modal header="怪しい" handleCloseModal={handleCloseSuspectModal}>
+      <div className="text-xs text-center md:text-lg font-bold mb-4">
+        怪しいプレイヤーを選んでください。
+      </div>
+      <div className="flex flex-col md:flex-row justify-end items-center gap-4">
+        <Button
+          className="w-32 h-8 md:h-12"
+          onClick={handleCloseSuspectModal}
+          variant="secondary"
+        >
+          キャンセル
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -61,13 +61,15 @@ export function SuspectModal({
         </div>
       </div>
       <div className="flex flex-col md:flex-row justify-end items-center gap-4">
-        <Button
-          className="w-32 h-8 md:h-12"
-          onClick={handleCloseSuspectModal}
-          variant="secondary"
-        >
-          キャンセル
-        </Button>
+        {mode === "suspect" && (
+          <Button
+            className="w-32 h-8 md:h-12"
+            onClick={handleCloseSuspectModal}
+            variant="secondary"
+          >
+            キャンセル
+          </Button>
+        )}
       </div>
     </Modal>
   );

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -2,11 +2,13 @@ import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/button/Button";
 
 type SuspectModalProps = {
+  players: string[];
   handleSuspect?: () => Promise<void>;
   handleCloseSuspectModal: () => void;
 };
 
 export function SuspectModal({
+  players,
   handleCloseSuspectModal,
   handleSuspect,
 }: SuspectModalProps) {
@@ -14,6 +16,16 @@ export function SuspectModal({
     <Modal header="怪しい" handleCloseModal={handleCloseSuspectModal}>
       <div className="text-xs text-center md:text-lg font-bold mb-4">
         怪しいプレイヤーを選んでください。
+      </div>
+      <div className="w-full flex gap-2">
+        {players.map((player, idx) => (
+          <button
+            key={`${player}-${idx}`}
+            className="h-16 px-6 border border-primary border-solid rounded flex justify-center items-center"
+          >
+            {player}
+          </button>
+        ))}
       </div>
       <div className="flex flex-col md:flex-row justify-end items-center gap-4">
         <Button

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -22,31 +22,11 @@ export function SuspectModal({
   handleOpenResultModal,
   currentPlayer,
 }: SuspectModalProps) {
-  const [timeLeft, setTimeLeft] = useState(30);
-
-  useEffect(() => {
-    if (handleOpenResultModal === undefined || mode !== "poll") return;
-    if (timeLeft > 0) {
-      const timer = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
-      clearTimeout(timer);
-    } else {
-      handleCloseSuspectModal();
-      handleOpenResultModal();
-    }
-  }, [timeLeft]);
-
   return (
     <Modal
       header="怪しいプレイヤー選択"
       handleCloseModal={handleCloseSuspectModal}
     >
-      {mode === "poll" && (
-        <div>
-          <p className="mb-4 text-center font-bold text-xl">
-            残り時間: {timeLeft}秒
-          </p>
-        </div>
-      )}
       <div className="w-full flex justify-center">
         <div className="flex gap-2 mb-4 flex-wrap">
           {players

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -1,21 +1,46 @@
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/button/Button";
+import { useState, useEffect } from "react";
 
 type SuspectModalProps = {
+  mode: "suspect" | "poll";
   players: string[];
   suspectingPlayer: string | undefined;
   handleSuspect: (name: string) => void;
   handleCloseSuspectModal: () => void;
+  handleOpenResultModal?: () => void;
 };
 
 export function SuspectModal({
+  mode,
   players,
   suspectingPlayer,
   handleCloseSuspectModal,
   handleSuspect,
+  handleOpenResultModal,
 }: SuspectModalProps) {
+  const [timeLeft, setTimeLeft] = useState(30);
+
+  useEffect(() => {
+    if (!handleOpenResultModal) return;
+    if (mode === "poll" && timeLeft > 0) {
+      const timer = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
+      return () => clearTimeout(timer);
+    } else if (mode === "poll" && timeLeft === 0) {
+      handleCloseSuspectModal();
+      handleOpenResultModal();
+    }
+  }, [timeLeft]);
+
   return (
     <Modal header="怪しいプレイヤー選択" handleCloseModal={handleCloseSuspectModal}>
+      {mode === "poll" && (
+        <div>
+          <p className="mb-4 text-center font-bold text-xl">
+            残り時間: {timeLeft}秒
+          </p>
+        </div>
+      )}
       <div className="w-full flex justify-center">
         <div className="flex gap-2 mb-4 flex-wrap">
           {players.map((player) => (

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -3,12 +3,14 @@ import { Button } from "@/components/ui/button/Button";
 
 type SuspectModalProps = {
   players: string[];
-  handleSuspect?: () => Promise<void>;
+  suspectingPlayer: string | undefined;
+  handleSuspect: (name: string) => void;
   handleCloseSuspectModal: () => void;
 };
 
 export function SuspectModal({
   players,
+  suspectingPlayer,
   handleCloseSuspectModal,
   handleSuspect,
 }: SuspectModalProps) {
@@ -18,9 +20,10 @@ export function SuspectModal({
         怪しいプレイヤーを選んでください。
       </div>
       <div className="w-full flex gap-2">
-        {players.map((player, idx) => (
+        {players.map((player) => (
           <button
-            key={`${player}-${idx}`}
+            onClick={() => handleSuspect(player)}
+            key={player}
             className="h-16 px-6 border border-primary border-solid rounded flex justify-center items-center"
           >
             {player}

--- a/app/src/components/ui/chess/modal/Suspect.tsx
+++ b/app/src/components/ui/chess/modal/Suspect.tsx
@@ -15,22 +15,21 @@ export function SuspectModal({
   handleSuspect,
 }: SuspectModalProps) {
   return (
-    <Modal header="怪しい" handleCloseModal={handleCloseSuspectModal}>
-      <div className="text-xs text-center md:text-lg font-bold mb-4">
-        怪しいプレイヤーを選んでください。
-      </div>
-      <div className="w-full flex gap-2">
-        {players.map((player) => (
-          <button
-            onClick={() => handleSuspect(player)}
-            key={player}
-            type="button"
-            disabled={player === suspectingPlayer}
-            className="h-16 px-6 border border-primary border-solid rounded flex justify-center items-center"
-          >
-            {player}
-          </button>
-        ))}
+    <Modal header="怪しいプレイヤー選択" handleCloseModal={handleCloseSuspectModal}>
+      <div className="w-full flex justify-center">
+        <div className="flex gap-2 mb-4 flex-wrap">
+          {players.map((player) => (
+            <Button
+              onClick={() => handleSuspect(player)}
+              variant="secondary"
+              key={player}
+              disabled={player === suspectingPlayer}
+              className="h-8 md:h-16 px-3 md:px-6 border border-primary border-solid rounded flex justify-center items-center"
+            >
+              {player}
+            </Button>
+          ))}
+        </div>
       </div>
       <div className="flex flex-col md:flex-row justify-end items-center gap-4">
         <Button

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 import { useGameDataAPI } from "@/adapters/api/game/api";
 import { setUpInitialBoard } from "@/components/ui/chess/initialBoard";
@@ -24,10 +24,11 @@ type ChessBoardHookProps = {
 };
 
 export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
+  const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
-  const playersQuery = queryParams.get("players") ?? '';
+  const playersQuery = queryParams.get("players") ?? "";
 
-  const players = playersQuery.split(',');
+  const players = playersQuery.split(",");
 
   const { showError, showAlert } = useAlert();
 
@@ -66,7 +67,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     board: Array(8).fill(Array(8).fill(undefined)),
     turn: 0,
     fiftyMoveRuleTurn: 0,
-    playing: '',
+    playing: "",
   });
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -295,6 +296,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
     // cpuのターン。レスポンス早くてもびっくりするので、少し待たせる
     setIsPlayerTurn(false);
+    setBoardStatus({...newBoardStatus, playing: 'CPU'});
     setTimeout(() => {
       cpuHook.cpuMove(newBoardStatus, isEnemyChecked, enemyEscapeMoves);
       setIsPlayerTurn(true);
@@ -396,7 +398,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
               setIsPlayerTurn(true);
             }, 1000);
           }
-          setBoardStatus({...initialBoard, playing });
+          setBoardStatus({ ...initialBoard, playing });
         } else {
           setBoardStatus(latestBoardStatus.gameData);
           // プレイヤーが白で、ターンが偶数、プレイヤーが黒で、ターンが奇数の場合はプレイヤーのターン

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -55,6 +55,8 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
   const [isRetireModalOpen, setIsRetireModalOpen] = useState<boolean>(false);
 
+  const [isSuspectModalOpen, setIsSuspectModalOpen] = useState<boolean>(false);
+
   const [gameStatus, setGameStatus] = useState<{
     player: GameStatus;
     enemy: GameStatus;
@@ -357,6 +359,14 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     setIsRetireModalOpen(false);
   };
 
+  const handleClickSuspectModal = () => {
+    setIsSuspectModalOpen(true);
+  };
+
+  const handleCloseSuspectModal = () => {
+    setIsSuspectModalOpen(false);
+  };
+
   const handleReturnHome = () => {
     try {
       gameDataAPI.delete();
@@ -470,11 +480,14 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     handleRetire,
     handleReturnHome,
     handleCloseRetireModal,
+    handleClickSuspectModal,
+    handleCloseSuspectModal,
     gameStatus,
     isPlayerTurn,
     promotionInfo,
     isRetireModalOpen,
     isRuleBookOpen,
+    isSuspectModalOpen,
     isLoading,
   };
 };

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -49,6 +49,8 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     | undefined
   >(undefined);
 
+  const [suspectingPlayer, setSuspectingPlayer] = useState<string | undefined>();
+
   const [isPlayerTurn, setIsPlayerTurn] = useState<boolean>(false);
 
   const [isRuleBookOpen, setIsRuleBookOpen] = useState<boolean>(false);
@@ -343,6 +345,10 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     callback(newBoard);
   };
 
+  const handleClickSuspectingPlayer = (name: string) => {
+    setSuspectingPlayer(name);
+  };
+
   const handleClickRule = () => {
     setIsRuleBookOpen(true);
   };
@@ -469,26 +475,28 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
   }, [playerColor]);
 
   return {
+    players,
     boardStatus,
     selectedPiecePosition,
     movablePositions,
+    gameStatus,
+    isLoading,
+    isPlayerTurn,
+    isSuspectModalOpen,
+    promotionInfo,
+    isRuleBookOpen,
+    isRetireModalOpen,
+    suspectingPlayer,
+    handleClickSuspectingPlayer,
     handleClickMass,
-    handleClickRule,
-    handleCloseRuleBook,
     handleClickPromotion,
+    handleCloseRuleBook,
+    handleClickRule,
     handleClickRetireButton,
+    handleCloseRetireModal,
     handleRetire,
     handleReturnHome,
-    handleCloseRetireModal,
     handleClickSuspectModal,
     handleCloseSuspectModal,
-    gameStatus,
-    isPlayerTurn,
-    promotionInfo,
-    isRetireModalOpen,
-    isRuleBookOpen,
-    isSuspectModalOpen,
-    isLoading,
-    players,
   };
 };

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -75,7 +75,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     board: Array(8).fill(Array(8).fill(undefined)),
     turn: 0,
     fiftyMoveRuleTurn: 0,
-    playing: "",
+    currentPlayer: "",
   });
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -309,7 +309,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
     // cpuのターン。レスポンス早くてもびっくりするので、少し待たせる
     setIsPlayerTurn(false);
-    setBoardStatus({ ...newBoardStatus, playing: "CPU" });
+    setBoardStatus({ ...newBoardStatus, currentPlayer: "CPU" });
     setTimeout(() => {
       cpuHook.cpuMove(newBoardStatus, isEnemyChecked, enemyEscapeMoves);
       setIsPlayerTurn(true);
@@ -412,7 +412,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
     setIsLoading(true);
     const playerPieceIdPrefix = playerColor === "white" ? "w" : "b";
-    const playing = playerColor === "white" ? players[0] : "CPU";
+    const currentPlayer = playerColor === "white" ? players[0] : "CPU";
     const initialBoard = setUpInitialBoard(playerPieceIdPrefix);
 
     (async () => {
@@ -427,7 +427,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
               setIsPlayerTurn(true);
             }, 1000);
           }
-          setBoardStatus({ ...initialBoard, playing });
+          setBoardStatus({ ...initialBoard, currentPlayer });
         } else {
           setBoardStatus(latestBoardStatus.gameData);
           // プレイヤーが白で、ターンが偶数、プレイヤーが黒で、ターンが奇数の場合はプレイヤーのターン

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -489,5 +489,6 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     isRuleBookOpen,
     isSuspectModalOpen,
     isLoading,
+    players,
   };
 };

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -78,8 +78,6 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     playing: "",
   });
 
-  const [gameResult, setGameResult] = useState<string>('');
-
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const gameDataAPI = useGameDataAPI();

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -49,7 +49,9 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     | undefined
   >(undefined);
 
-  const [suspectingPlayer, setSuspectingPlayer] = useState<string | undefined>();
+  const [suspectingPlayer, setSuspectingPlayer] = useState<
+    string | undefined
+  >();
 
   const [isPlayerTurn, setIsPlayerTurn] = useState<boolean>(false);
 

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -429,13 +429,19 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
           }
           setBoardStatus({ ...initialBoard, currentPlayer });
         } else {
-          setBoardStatus(latestBoardStatus.gameData);
           // プレイヤーが白で、ターンが偶数、プレイヤーが黒で、ターンが奇数の場合はプレイヤーのターン
           const isPlayerTurnInLatest =
             (playerColor === "white" &&
               latestBoardStatus.gameData.turn % 2 === 0) ||
             (playerColor === "black" &&
               latestBoardStatus.gameData.turn % 2 === 1);
+          // If it's player team's turn, I'll set the current player to the player's name.
+          const currentPlayer = isPlayerTurnInLatest
+            ? players[
+                Math.floor(latestBoardStatus.gameData.turn / 2) % players.length
+              ]
+            : "CPU";
+          setBoardStatus({ ...latestBoardStatus.gameData, currentPlayer });
           setIsPlayerTurn(isPlayerTurnInLatest);
 
           // プレイヤーのターンでない場合はCPUの処理を行う

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -153,7 +153,12 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     };
   };
 
-  const cpuHook = useCpu({ setBoardStatus, playerColor, moveCallback });
+  const cpuHook = useCpu({
+    setBoardStatus,
+    players,
+    playerColor,
+    moveCallback,
+  });
 
   const handleSelectPiece = (position: Position) => {
     const piece = boardStatus.board[position.y][position.x];
@@ -296,7 +301,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
     // cpuのターン。レスポンス早くてもびっくりするので、少し待たせる
     setIsPlayerTurn(false);
-    setBoardStatus({...newBoardStatus, playing: 'CPU'});
+    setBoardStatus({ ...newBoardStatus, playing: "CPU" });
     setTimeout(() => {
       cpuHook.cpuMove(newBoardStatus, isEnemyChecked, enemyEscapeMoves);
       setIsPlayerTurn(true);

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -61,6 +61,8 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
   const [isSuspectModalOpen, setIsSuspectModalOpen] = useState<boolean>(false);
 
+  const [isResultModalOpen, setIsResultModalOpen] = useState<boolean>(false);
+
   const [gameStatus, setGameStatus] = useState<{
     player: GameStatus;
     enemy: GameStatus;
@@ -75,6 +77,8 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     fiftyMoveRuleTurn: 0,
     playing: "",
   });
+
+  const [gameResult, setGameResult] = useState<string>('');
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -375,6 +379,10 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     setIsSuspectModalOpen(false);
   };
 
+  const handleOpenResultModal = () => {
+    setIsResultModalOpen(true);
+  };
+
   const handleReturnHome = () => {
     try {
       gameDataAPI.delete();
@@ -489,6 +497,8 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
     isRuleBookOpen,
     isRetireModalOpen,
     suspectingPlayer,
+    isResultModalOpen,
+    handleOpenResultModal,
     handleClickSuspectingPlayer,
     handleClickMass,
     handleClickPromotion,

--- a/app/src/components/ui/chess/useChessBoard.ts
+++ b/app/src/components/ui/chess/useChessBoard.ts
@@ -24,11 +24,10 @@ type ChessBoardHookProps = {
 };
 
 export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
-  const [boardStatus, setBoardStatus] = useState<BoardStatus>({
-    board: Array(8).fill(Array(8).fill(undefined)),
-    turn: 0,
-    fiftyMoveRuleTurn: 0,
-  });
+  const queryParams = new URLSearchParams(location.search);
+  const playersQuery = queryParams.get("players") ?? '';
+
+  const players = playersQuery.split(',');
 
   const { showError, showAlert } = useAlert();
 
@@ -61,6 +60,13 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
   }>({
     player: "playing",
     enemy: "playing",
+  });
+
+  const [boardStatus, setBoardStatus] = useState<BoardStatus>({
+    board: Array(8).fill(Array(8).fill(undefined)),
+    turn: 0,
+    fiftyMoveRuleTurn: 0,
+    playing: '',
   });
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -375,13 +381,13 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
 
     setIsLoading(true);
     const playerPieceIdPrefix = playerColor === "white" ? "w" : "b";
+    const playing = playerColor === "white" ? players[0] : "CPU";
     const initialBoard = setUpInitialBoard(playerPieceIdPrefix);
 
     (async () => {
       try {
         const latestBoardStatus = await gameDataAPI.findLatest();
         if (isNullOrUndefined(latestBoardStatus)) {
-          setBoardStatus(initialBoard);
           // プレイヤーが黒の場合は、CPUが先手で動く
           setIsPlayerTurn(playerColor === "white");
           if (playerColor === "black") {
@@ -390,6 +396,7 @@ export const useChessBoard = ({ playerColor }: ChessBoardHookProps) => {
               setIsPlayerTurn(true);
             }, 1000);
           }
+          setBoardStatus({...initialBoard, playing });
         } else {
           setBoardStatus(latestBoardStatus.gameData);
           // プレイヤーが白で、ターンが偶数、プレイヤーが黒で、ターンが奇数の場合はプレイヤーのターン

--- a/app/src/components/ui/chess/useCpu.ts
+++ b/app/src/components/ui/chess/useCpu.ts
@@ -102,8 +102,8 @@ export const useCpu = ({
       playerColor === "white"
         ? Math.floor((newBoardStatusInCpuTurn.turn + 1) / 2)
         : Math.floor(newBoardStatusInCpuTurn.turn / 2);
-    const playing = players[index % players.length];
-    setBoardStatus({ ...newBoardStatusInCpuTurn, playing });
+    const currentPlayer = players[index % players.length];
+    setBoardStatus({ ...newBoardStatusInCpuTurn, currentPlayer });
 
     const kingPosition = getMyPieces(
       newBoardStatusInCpuTurn.board,

--- a/app/src/components/ui/chess/useCpu.ts
+++ b/app/src/components/ui/chess/useCpu.ts
@@ -16,7 +16,7 @@ import { isNullOrUndefined } from "@/utils/typeGuard";
 
 type CpuHookProps = {
   setBoardStatus: Dispatch<SetStateAction<BoardStatus>>;
-  players: string;
+  players: string[];
   playerColor: "white" | "black" | undefined;
   moveCallback: (
     board: BoardStatus,

--- a/app/src/components/ui/chess/useCpu.ts
+++ b/app/src/components/ui/chess/useCpu.ts
@@ -16,6 +16,7 @@ import { isNullOrUndefined } from "@/utils/typeGuard";
 
 type CpuHookProps = {
   setBoardStatus: Dispatch<SetStateAction<BoardStatus>>;
+  players: string;
   playerColor: "white" | "black" | undefined;
   moveCallback: (
     board: BoardStatus,
@@ -34,6 +35,7 @@ type CpuHookProps = {
 
 export const useCpu = ({
   setBoardStatus,
+  players,
   playerColor,
   moveCallback,
 }: CpuHookProps) => {
@@ -95,7 +97,13 @@ export const useCpu = ({
       randomPosition.to,
       false,
     );
-    setBoardStatus(newBoardStatusInCpuTurn);
+
+    const index =
+      playerColor === "white"
+        ? Math.floor((newBoardStatusInCpuTurn.turn + 1) / 2)
+        : Math.floor(newBoardStatusInCpuTurn.turn / 2);
+    const playing = players[index % players.length];
+    setBoardStatus({ ...newBoardStatusInCpuTurn, playing });
 
     const kingPosition = getMyPieces(
       newBoardStatusInCpuTurn.board,

--- a/app/src/components/ui/chess/useCpu.ts
+++ b/app/src/components/ui/chess/useCpu.ts
@@ -98,10 +98,8 @@ export const useCpu = ({
       false,
     );
 
-    const index =
-      playerColor === "white"
-        ? Math.floor((newBoardStatusInCpuTurn.turn + 1) / 2)
-        : Math.floor(newBoardStatusInCpuTurn.turn / 2);
+    // TODO: Move this logic to useChessBoard ?
+    const index = Math.floor(newBoardStatusInCpuTurn.turn / 2);
     const currentPlayer = players[index % players.length];
     setBoardStatus({ ...newBoardStatusInCpuTurn, currentPlayer });
 

--- a/app/src/domains/game/entity.ts
+++ b/app/src/domains/game/entity.ts
@@ -26,6 +26,7 @@ export const newGame = (): Game => ({
     board: Array(8).fill(Array(8).fill(undefined)),
     turn: 0,
     fiftyMoveRuleTurn: 0,
+    playing: "",
   },
   winner: undefined,
 });

--- a/app/src/domains/game/entity.ts
+++ b/app/src/domains/game/entity.ts
@@ -26,7 +26,7 @@ export const newGame = (): Game => ({
     board: Array(8).fill(Array(8).fill(undefined)),
     turn: 0,
     fiftyMoveRuleTurn: 0,
-    playing: "",
+    currentPlayer: "",
   },
   winner: undefined,
 });

--- a/app/src/domains/piece/common.ts
+++ b/app/src/domains/piece/common.ts
@@ -422,6 +422,7 @@ export const movePiece = (
     fiftyMoveRuleTurn: isFiftyMoveRuleTurnUpdate
       ? 0
       : boardStatus.fiftyMoveRuleTurn + 1,
+    playing: "",
   };
 };
 

--- a/app/src/domains/piece/common.ts
+++ b/app/src/domains/piece/common.ts
@@ -422,7 +422,7 @@ export const movePiece = (
     fiftyMoveRuleTurn: isFiftyMoveRuleTurnUpdate
       ? 0
       : boardStatus.fiftyMoveRuleTurn + 1,
-    playing: "",
+    currentPlayer: "",
   };
 };
 

--- a/app/src/domains/piece/piece.ts
+++ b/app/src/domains/piece/piece.ts
@@ -18,6 +18,7 @@ export type BoardStatus = {
   board: Board;
   turn: number;
   fiftyMoveRuleTurn: number;
+  playing: string;
 };
 
 export type PieceType = "P" | "R" | "N" | "B" | "Q" | "K";

--- a/app/src/domains/piece/piece.ts
+++ b/app/src/domains/piece/piece.ts
@@ -18,7 +18,7 @@ export type BoardStatus = {
   board: Board;
   turn: number;
   fiftyMoveRuleTurn: number;
-  playing: string;
+  currentPlayer: string;
 };
 
 export type PieceType = "P" | "R" | "N" | "B" | "Q" | "K";

--- a/app/src/domains/piece/piece.ts
+++ b/app/src/domains/piece/piece.ts
@@ -18,6 +18,7 @@ export type BoardStatus = {
   board: Board;
   turn: number;
   fiftyMoveRuleTurn: number;
+  // TODO: Since this can be calculated from turn and player's color, it should be removed.
   currentPlayer: string;
 };
 


### PR DESCRIPTION
## やったこと
- 役職選択からゲーム開始を繋げる
- ゲームに与えられたプレイヤーのターンを表示
- 怪しいボタン・モーダル追加（随時怪しいプレイヤーを選ぶことができる）
- ゲーム終了後、30秒間モーダルでプレイヤー選択
- 30秒が過ぎると結果画面が出る

## できていないこと
- BEとの接続
- 結果の計算(まだ一画面での操作しかできない仕組みのため)